### PR TITLE
Add a restriction to CrossOrigin annotations

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -883,3 +883,13 @@ editor:
   parameters:
     - "component": "minor"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170609011313"
+editor:
+  name: "RestrictCORS"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "1.13.23"
+

--- a/src/main/java/com/atomist/springrest/addrestendpoint/OneEndpointController.java
+++ b/src/main/java/com/atomist/springrest/addrestendpoint/OneEndpointController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class OneEndpointController {
 
-    @CrossOrigin()
+    @CrossOrigin(origins = "http://localhost:8000")
     @RequestMapping(path = "/onePath")
     public OneEndpoint oneEndpoint(@RequestParam(value = "oneParam") String oneParam) {
         return new OneEndpoint(oneParam);


### PR DESCRIPTION
This is a recommended change from your friendly security advisers.
        
        While allowing cross-origin requests is essential for some local testing, it is 
        otherwise discouraged by ... people. As long as your local front end is at localhost:8080,
        you'll be able to test.

        If there is a particular reason that your service should allow more requests (like, it's a public API)
        then please comment on this PR and then close it or remove individual endpoints' changes.
        

Created by Atomist Editor `RestrictCORS`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170609011313"
editor:
  name: "RestrictCORS"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "1.13.23"

```